### PR TITLE
update xihe-test-v2

### DIFF
--- a/applications/xihe-test-v2/async-server/configmap.yaml
+++ b/applications/xihe-test-v2/async-server/configmap.yaml
@@ -41,6 +41,8 @@ data:
         signle_picture: "${BIGMODEL_SINGLE_PICTURE}"
         multiple_pictures: "${BIGMODEL_MULTI_PICTURES}"
         ai_detector: "${BIGMODEL_AI_DETECTOR}"
+        wukong_user: "${BIGMODEL_WUKONG_USER}"
+        baichuan: "${BIGMODEL_BAICHUAN}"
 
       obs:
         endpoint: "${VQA_OBS_ENDPOINT}"
@@ -72,6 +74,7 @@ data:
 
     mq:
       address: "${KAFKA_ADDRESS}"
+      version: "2.3.0"
       topics:
         fork: "xihe_fork_test"
         like: "xihe_like_test"
@@ -87,6 +90,12 @@ data:
         cloud: "xihe_cloud_test"
         async: "xihe_async_test"
         bigmodel: "xihe_bigmodel_test"
+    
+    redis:
+      db:
+        address: "${REDIS_ADDRESS}"
+        password: "${REDIS_PASSWORD}"
+        key_pair: "${KEY_PAIR}"
 
     watcher:
       time:

--- a/applications/xihe-test-v2/internal-server/configmap.yaml
+++ b/applications/xihe-test-v2/internal-server/configmap.yaml
@@ -35,6 +35,8 @@ data:
         course_work: course_work
         course_record: course_record
         cloud_conf: cloud_conf
+        api_apply: api_apply
+        api_info: api_info
 
     domain:
       min_name_length: 3
@@ -42,8 +44,8 @@ data:
       max_desc_length: 200
       max_title_length: 105
       min_title_length: 3
-      min_training_name_length: 1
-      max_training_name_length: 64
+      min_training_name_length: 5
+      max_training_name_length: 50
       max_training_desc_length: 256
       covers:
       - "1"

--- a/applications/xihe-test-v2/message-server/configmap.yaml
+++ b/applications/xihe-test-v2/message-server/configmap.yaml
@@ -38,6 +38,8 @@ data:
         course_work: course_work
         course_record: course_record
         cloud_conf: cloud_conf
+        api_apply: api_apply
+        api_info: api_info
 
     postgresql:
       db:
@@ -50,6 +52,11 @@ data:
       table:
         pod: pod
         async_task: async_task
+    
+    redis:
+      address: "${REDIS_ADDRESS}"
+      password: "${REDIS_PASSWORD}"
+      key_pair: "${KEY_PAIR}"
 
     domain:
       min_name_length: 3
@@ -57,8 +64,8 @@ data:
       max_desc_length: 200
       max_title_length: 105
       min_title_length: 3
-      min_training_name_length: 1
-      max_training_name_length: 64
+      min_training_name_length: 5
+      max_training_name_length: 50
       max_training_desc_length: 256
       covers:
       - "1"
@@ -137,6 +144,7 @@ data:
 
     mq:
       address: "${KAFKA_ADDRESS}"
+      version: "2.3.0"
       topics:
         fork: "xihe_fork_test"
         like: "xihe_like_test"


### PR DESCRIPTION
1. async-server: 增加大模型endpoint， kafka默认版本号， redis配置项
2. internal-server：同步和xihe-server相同的配置
3. message-server: 同步和xihe-server相同的配置，增加kafka默认版本号，redis配置项